### PR TITLE
Wunderbaum css in administrate namespace

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
 //= link_tree ../builds
+//= link wunderbaum/dist/wunderbaum.css

--- a/app/views/layouts/administrate/application.html.erb
+++ b/app/views/layouts/administrate/application.html.erb
@@ -9,6 +9,8 @@
     </title>
     
     <%= render "stylesheet" %>
+    
+    <%= stylesheet_link_tag("wunderbaum/dist/wunderbaum.css", media: "all", "data-turbo-track": "reload") %>
 
     <!-- wunderbaum -->
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -6,9 +6,6 @@ Rails.application.config.assets.version = "1.0"
 # Rails.application.config.assets.paths << Emoji.images_path
 Rails.application.config.assets.paths << Rails.root.join("node_modules")
 Rails.application.config.assets.paths << Rails.root.join("app/assets/fonts")
-Rails.application.config.assets.paths << Rails.root.join("node_modules", "wunderbaum", "dist")
-Rails.application.config.assets.precompile += %w[wunderbaum.css]
-
 
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path


### PR DESCRIPTION
move wunderbaum from initializer to load directly from node_nodules in layout file

Initializer is for use with sprockets. cssbundling will not touch that in order to precompile it for production.