### PR TITLE
Fix no full_path for nil error.

### DIFF
--- a/app/dashboards/isilon_folder_dashboard.rb
+++ b/app/dashboards/isilon_folder_dashboard.rb
@@ -64,6 +64,6 @@ class IsilonFolderDashboard < Administrate::BaseDashboard
   # across all pages of the admin dashboard.
   #
   def display_resource(isilon_folder)
-    isilon_folder.full_path
+    isilon_folder&.full_path
   end
 end

--- a/app/views/fields/belongs_to/_form.html.erb
+++ b/app/views/fields/belongs_to/_form.html.erb
@@ -20,9 +20,8 @@ that displays all possible records to associate with.
   <%= f.label field.permitted_attribute %>
 </div>
 <div class="field-unit__field">
-  <%# binding.pry %>
   <%= link_to(
       field.display_associated_resource,
       [namespace, field.data],
-    ) %>
+    ) unless field.data.nil? %>
 </div>


### PR DESCRIPTION
When you GET admin/isilon_assets/new with an empty database an error happens because full_path is not present on nil.