### PR TITLE
IMT-101 investigate missing directories

### DIFF
--- a/app/controllers/admin/volumes_controller.rb
+++ b/app/controllers/admin/volumes_controller.rb
@@ -1,8 +1,8 @@
 module Admin
   class VolumesController < Admin::ApplicationController
-    def show
-      @volume = Volume.find(params[:id])
-      super
-    end
+    # def show
+    #   @volume = Volume.find(params[:id])
+    #   super
+    # end
   end
 end

--- a/app/dashboards/isilon_folder_dashboard.rb
+++ b/app/dashboards/isilon_folder_dashboard.rb
@@ -38,6 +38,7 @@ class IsilonFolderDashboard < Administrate::BaseDashboard
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
+    child_folders
     isilon_assets
   ].freeze
 

--- a/app/dashboards/volume_dashboard.rb
+++ b/app/dashboards/volume_dashboard.rb
@@ -10,7 +10,9 @@ class VolumeDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     id: Field::Number,
     name: Field::String,
-    isilon_folders: Field::HasMany.with_options(limit: 20),
+    top_level_folders: Field::HasMany.with_options(
+      limit: 20
+    ),
     created_at: Field::DateTime,
     updated_at: Field::DateTime
   }.freeze
@@ -28,7 +30,7 @@ class VolumeDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
     name
-    isilon_folders
+    top_level_folders
   ].freeze
 
   # FORM_ATTRIBUTES

--- a/app/models/isilon_folder.rb
+++ b/app/models/isilon_folder.rb
@@ -3,4 +3,14 @@ class IsilonFolder < ApplicationRecord
   belongs_to :parent_folder, class_name: "IsilonFolder", foreign_key: "parent_folder_id", optional: true
   has_many :child_folders, class_name: "IsilonFolder", foreign_key: "parent_folder_id"
   has_many :isilon_assets, foreign_key: "parent_folder_id"
+
+  def breadcrumb_trail
+    crumbs = []
+    current = self
+    while current
+      crumbs.unshift(current)
+      current = current.parent_folder
+    end
+    crumbs
+  end
 end

--- a/app/models/volume.rb
+++ b/app/models/volume.rb
@@ -1,4 +1,5 @@
 class Volume < ApplicationRecord
   has_many :isilon_folders
+  has_many :top_level_folders, -> { where(parent_folder_id: nil) }, class_name: "IsilonFolder"
   has_many :isilon_assets, through: :isilon_folders
 end

--- a/app/services/sync_service/assets.rb
+++ b/app/services/sync_service/assets.rb
@@ -13,38 +13,42 @@ module SyncService
       @csv_path = params.fetch(:csv_path)
       @log = Logger.new("log/isilon-sync.log")
       @stdout = Logger.new($stdout)
-      @parent_volume_name = check_volume(@csv_path)
+      @parent_volume = check_volume(@csv_path)
       stdout_and_log(%(Syncing assets from #{@csv_path}))
     end
 
     def sync
       imported = 0
       CSV.foreach(@csv_path, headers: true) do |row|
+        next if row["Path"].include?(".DS_Store") # putting this here prevents empty folders
         asset = IsilonAsset.new(
-          isilon_path:               row["Path"],
+          isilon_path:               set_full_path(row["Path"]),
           isilon_name:               get_name(row["Path"]),
           file_size:                 row["Size"],
           file_type:                 row["Type"],
           file_checksum:             row["Hash"],
           last_modified_in_isilon:   row["ModifiedAt"],
-          date_created_in_isilon:    row["CreatedAt"]
+          date_created_in_isilon:    row["CreatedAt"],
+          parent_folder_id:          get_asset_parent_id(row["Path"].split("/").compact_blank[1...-1]).id,
         )
 
-        next if asset.isilon_path.count("/") < 3
-
-        directory_check(asset)
-
-        asset.parent_folder_id = get_parent_folder(asset.isilon_path)
-
-        begin
-          imported += 1 if asset.save!
-        rescue
-          stdout_and_log("Failed to import asset #{asset.isilon_path}: #{asset.errors.full_messages.join(", ")}", level: :error)
+        if directory_check(asset)
+          begin
+            imported += 1 if asset.save!
+          rescue => e
+            stdout_and_log("Failed to import asset #{asset.isilon_path}: #{e.message}", level: :error)
+          end
+        else
+          stdout_and_log("Skipping asset with invalid path: #{asset.isilon_path}", level: :warn)
         end
       end
 
-      puts "Imported #{imported} IsilonAsset records."
       stdout_and_log("Imported #{imported} IsilonAsset records.")
+    end
+
+    def set_full_path(path)
+      volume_segment = [ "/", @parent_volume.name ].join
+      path.gsub(volume_segment, "")
     end
 
     def check_volume(path)
@@ -52,58 +56,62 @@ module SyncService
       volume = first_row["Path"].split("/").compact_blank[0]
 
       if Volume.exists?(name: volume)
-        volume
+        stdout_and_log("Volume #{volume} already exists.")
+        Volume.find_by(name: volume)
       else
         new_volume = Volume.create!(name: volume)
         begin
           new_volume.save!
+          stdout_and_log("Created new volume: #{new_volume.name}")
         rescue => e
           stdout_and_log("Unable to save volume: #{volume}; #{e.message}", level: :error)
         end
-        new_volume.name
+        new_volume
       end
+    end
+
+    def directory_check(asset)
+      all_directories = asset.isilon_path.split("/").compact_blank
+      directories = all_directories[0...-1]
+      return if directories.empty?
+      volume = Volume.find_by(name: @parent_volume.name)
+
+      (directories.size).downto(0) do |i|
+        if directories.present?
+          parent_folder = get_folder_parent_id(directories)
+          current_path = "/" + directories.join("/")
+
+          folder = IsilonFolder.find_or_create_by!(volume_id: volume.id, full_path: current_path)
+          folder.update!(parent_folder_id: parent_folder.id) if parent_folder.present?
+          directories.pop unless i == 0
+
+          begin
+            folder.save!
+          rescue => e
+            stdout_and_log("Unable to save folder: #{current_path}; #{e.message}", level: :error)
+          end
+        end
+      end
+    end
+
+    def get_folder_parent_id(path)
+      path = path[0...-1]
+      path = path.join("/")
+      IsilonFolder.find_or_create_by!(volume_id: @parent_volume.id, full_path: "/#{path}") if path.present?
+    end
+
+    def get_asset_parent_id(path)
+      path = path.join("/")
+      IsilonFolder.find_or_create_by!(volume_id: @parent_volume.id, full_path: "/#{path}") if path.present?
     end
 
     def get_name(path)
       path.split("/").last
     end
 
-    def get_parent_folder(path)
-      parent_path = "/" + path.split("/").compact_blank[0..-2].join("/")
-      folder = IsilonFolder.find_or_create_by(full_path: parent_path)
-      folder.volume_id = Volume.find_by(name: @parent_volume_name).id
-      begin
-        folder.save!
-      rescue => e
-        stdout_and_log("Error saving parent_folder: #{parent_path}; #{e.message}", level: :error)
-      end
-      folder.id
-    end
-
-    def directory_check(asset)
-      directories = asset.isilon_path.split("/").compact_blank[0..-2]
-      i = -2
-      directories.each_with_index do |dir, index|
-        i = i-index
-        new_path = "/" + asset.isilon_path.split("/").compact_blank[0..i].join("/")
-        next if new_path.count("/") < 3 # Skip if the path is too short, parent_folder will already exist
-
-        parent_path = "/" + asset.isilon_path.split("/").compact_blank[0..i].join("/")
-        folder = IsilonFolder.find_or_create_by(full_path: new_path)
-
-        folder.volume_id = Volume.find_by(name: @parent_volume_name).id
-        folder.parent_folder_id = get_parent_folder(parent_path) # parent folder must already exist
-        begin
-          folder.save!
-        rescue => e
-          stdout_and_log("Unable to save folder: #{new_path}; #{e.message}", level: :error)
-        end
-      end
-    end
-
     def stdout_and_log(message, level: :info)
       @log.send(level, message)
-      # @stdout.send(level, message)
+      @stdout.send(level, message)
     end
   end
 end

--- a/app/views/admin/isilon_folders/show.html.erb
+++ b/app/views/admin/isilon_folders/show.html.erb
@@ -1,0 +1,77 @@
+<%#
+# Show
+
+This view is the template for the show page.
+It renders the attributes of a resource,
+as well as a link to its edit page.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Show][1].
+  Contains methods for accessing the resource to be displayed on the page,
+  as well as helpers for describing how each attribute of the resource
+  should be displayed.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Show
+%>
+
+<% content_for(:title) { t("administrate.actions.show_resource", name: page.page_title) } %>
+
+<header class="main-content__header">
+  <h1 class="main-content__page-title">
+    <%= content_for(:title) %>
+  </h1>
+
+  <div>
+    <%= link_to(
+      t("administrate.actions.edit_resource", name: page.page_title),
+      [:edit, namespace, page.resource],
+      class: "button",
+    ) if accessible_action?(page.resource, :edit) %>
+
+    <%= link_to(
+      t("administrate.actions.destroy"),
+      [namespace, page.resource],
+      class: "button button--danger",
+      method: :delete,
+      data: { confirm: t("administrate.actions.confirm") }
+    ) if accessible_action?(page.resource, :destroy) %>
+  </div>
+</header>
+
+<section class="main-content__body">
+  <nav class="breadcrumbs">
+  <%= link_to "Volumes", admin_volumes_path %> &raquo;
+  <%= link_to page.resource.volume.name, admin_volume_path(page.resource.volume) %>
+    <% page.resource.breadcrumb_trail.each_with_index do |folder, idx| %>
+      &raquo;
+      <% if idx == page.resource.breadcrumb_trail.size - 1 %>
+        <%= folder.full_path %>
+      <% else %>
+        <%= link_to folder.full_path, admin_isilon_folder_path(folder) %>
+      <% end %>
+    <% end %>
+  </nav>
+  <dl>
+    <% page.attributes.each do |title, attributes| %>
+      <fieldset class="<%= "field-unit--nested" if title.present? %>">
+        <% if title.present? %>
+          <legend><%= t "helpers.label.#{page.resource_name}.#{title}", default: title %></legend>
+        <% end %>
+
+        <% attributes.each do |attribute| %>
+          <dt class="attribute-label" id="<%= attribute.name %>">
+          <%= t(
+            "helpers.label.#{resource_name}.#{attribute.name}",
+            default: page.resource.class.human_attribute_name(attribute.name),
+          ) %>
+          </dt>
+
+          <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
+              ><%= render_field attribute, page: page %></dd>
+        <% end %>
+      </fieldset>
+    <% end %>
+  </dl>
+</section>

--- a/app/views/admin/volumes/show.html.erb
+++ b/app/views/admin/volumes/show.html.erb
@@ -1,0 +1,66 @@
+<%#
+# Show
+
+This view is the template for the show page.
+It renders the attributes of a resource,
+as well as a link to its edit page.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Show][1].
+  Contains methods for accessing the resource to be displayed on the page,
+  as well as helpers for describing how each attribute of the resource
+  should be displayed.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Show
+%>
+
+<% content_for(:title) { t("administrate.actions.show_resource", name: page.page_title) } %>
+
+<header class="main-content__header">
+  <h1 class="main-content__page-title">
+    <%= content_for(:title) %>
+  </h1>
+
+  <div>
+    <%= link_to(
+      t("administrate.actions.edit_resource", name: page.page_title),
+      [:edit, namespace, page.resource],
+      class: "button",
+    ) if accessible_action?(page.resource, :edit) %>
+
+    <%= link_to(
+      t("administrate.actions.destroy"),
+      [namespace, page.resource],
+      class: "button button--danger",
+      method: :delete,
+      data: { confirm: t("administrate.actions.confirm") }
+    ) if accessible_action?(page.resource, :destroy) %>
+  </div>
+</header>
+
+<section class="main-content__body">
+  <%= link_to "Volumes", admin_volumes_path %> &raquo;
+  <dl>
+    <% page.attributes.each do |title, attributes| %>
+      <fieldset class="<%= "field-unit--nested" if title.present? %>">
+        <% if title.present? %>
+          <legend><%= t "helpers.label.#{page.resource_name}.#{title}", default: title %></legend>
+        <% end %>
+
+        <% attributes.each do |attribute| %>
+          <dt class="attribute-label" id="<%= attribute.name %>">
+          <%= t(
+            "helpers.label.#{resource_name}.#{attribute.name}",
+            default: page.resource.class.human_attribute_name(attribute.name),
+          ) %>
+          </dt>
+
+          <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
+              ><%= render_field attribute, page: page %></dd>
+        <% end %>
+      </fieldset>
+    <% end %>
+  </dl>
+</section>


### PR DESCRIPTION
Refactors asset ingest script to correct parent/child assigns. Updates views to display children (folders and assets) of volumes and folders.

This fixes the child/parent settings but does not yet find the missing directories. It does rule out the script as a possible source. The missing directories are not in the csv file and should be addressed on the isilon end.

This work can be merged on the app side and I'll look into the CSV's and the Isilon export script next.