### PR TITLE
IMT-74 Add instructions to allow use of Google OAuth2 and to seed the

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,21 @@ application up and running.
 
 * cd into cloned repo and bundle install, updating ruby if needed
 
+* From the password vault app, in the "dev team" vault, search for the IMT_USER_LIST note and execute the export command
+
+* From the password vault app, in the "dev team" vault, search for the "Google OAuth Isilon Tracker Dev" note and execute the
+  export commands
+
 * Run rails db:setup to initialize db and populate wtih seeds from config
 
 * Run rails sync:assets["scan_output.applications-backup.csv"] (included in the repo) for sample data
 
 * Run bin/dev to start the development server and watch for css/js changes
+
+* If authentication is required, you will see the login page. Click on the "Sign in with GoogleOauth2" button and
+  connect to your Google account. If you encounter the Google Account Profile Page, return to Isilon tracker
+  application and reauthenticate. You should be take to the desired page. NOTE: This is a known issue which
+  we will address in a future release.
 
 * Javascript Filetree explorer view available at root path, administrate backend at /admin. Omniauth logins required for both.
   Initial seed creates user templelibraries@gmail.com. Pass in 1pass, if needed.


### PR DESCRIPTION
- Instructions to allow use of Google OAuth2 tokens for a localhost dev site
- Instructions to seed user table from an environment variable