### PR TITLE
IMT-134-fix-shibboleth-callback-to-redirect-back-to-the-app-not-google

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -272,7 +272,10 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   config.omniauth :google_oauth2, ENV["GOOGLE_OAUTH_CLIENT_ID"], ENV["GOOGLE_OAUTH_SECRET"],
-    scope: "email"
+      scope: "openid,email,profile",
+      prompt: "select_account",
+      hd: "temple.edu",                  # <- force Workspace domain path
+      include_granted_scopes: true
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or


### PR DESCRIPTION
This tells Google, “this sign-in is for temple.edu,” which uses the Workspace/SAML path. This usually preserves the OAuth ‘continue’ parameter better.