### PR TITLE
IMT-150-multiple-syncs-fail

### DIFF
--- a/spec/services/sync_service/assets_spec.rb
+++ b/spec/services/sync_service/assets_spec.rb
@@ -150,4 +150,77 @@ RSpec.describe SyncService::Assets, type: :service do
       expect(normal_asset.migration_status).to eq(default_migration_status)
     end
   end
+
+  describe '#find_or_create_folder_safely' do
+    let(:csv_path) { file_fixture('automation_rules_sync.csv').to_s }
+    let(:service) { described_class.new(csv_path: csv_path) }
+
+    context 'when handling race conditions' do
+      it 'handles concurrent folder creation gracefully' do
+        volume_id = volume.id
+        folder_path = "/test/concurrent/folder"
+
+        # Simulate the race condition by stubbing find_or_create_by!
+        # to raise RecordNotUnique the first time, then succeed
+        allow(IsilonFolder).to receive(:find_or_create_by!).with(
+          volume_id: volume_id,
+          full_path: folder_path
+        ).and_raise(ActiveRecord::RecordNotUnique.new("Duplicate key")).once
+
+        # Create the folder that would be created by the "other process"
+        existing_folder = IsilonFolder.create!(
+          volume_id: volume_id,
+          full_path: folder_path
+        )
+
+        # Stub the find_by to return the existing folder (simulating successful retry)
+        allow(IsilonFolder).to receive(:find_by).with(
+          volume_id: volume_id,
+          full_path: folder_path
+        ).and_return(existing_folder)
+
+        # Test that our method handles the race condition gracefully
+        result = service.send(:find_or_create_folder_safely, volume_id, folder_path)
+
+        expect(result).to eq(existing_folder)
+        expect(result.volume_id).to eq(volume_id)
+        expect(result.full_path).to eq(folder_path)
+      end
+
+      it 'raises error when retries are exhausted' do
+        volume_id = volume.id
+        folder_path = "/test/failing/folder"
+
+        # Stub to always raise RecordNotUnique and never find existing folder
+        allow(IsilonFolder).to receive(:find_or_create_by!).with(
+          volume_id: volume_id,
+          full_path: folder_path
+        ).and_raise(ActiveRecord::RecordNotUnique.new("Duplicate key"))
+
+        allow(IsilonFolder).to receive(:find_by).with(
+          volume_id: volume_id,
+          full_path: folder_path
+        ).and_return(nil)
+
+        # Stub sleep to avoid actual delays in test
+        allow(service).to receive(:sleep)
+
+        expect {
+          service.send(:find_or_create_folder_safely, volume_id, folder_path)
+        }.to raise_error(ActiveRecord::RecordNotFound, /Could not find or create folder after 3 retries/)
+      end
+
+      it 'creates folder successfully on first try when no conflict' do
+        volume_id = volume.id
+        folder_path = "/test/no/conflict"
+
+        result = service.send(:find_or_create_folder_safely, volume_id, folder_path)
+
+        expect(result).to be_a(IsilonFolder)
+        expect(result.volume_id).to eq(volume_id)
+        expect(result.full_path).to eq(folder_path)
+        expect(result.persisted?).to be true
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fix race condition in sync:assets task folder creation

Resolves PG::UniqueViolation errors when multiple sync processes attempt  to create the same folder simultaneously during CSV import operations.

Problem:
- Multiple sync processes running concurrently would fail with duplicate  key violations on index_isilon_folders_on_full_path

Solution:
- Implement find_or_create_folder_safely() with retry logic
- Added exponential backoff (0.1s, 0.2s, 0.3s delays) over 3 attempts  
- Falls back to finding existing folder when creation conflicts occur
- Add test covering race conditions
- Removed unused directory_check() method
