### PR TITLE
IMT-1500-multiple-syncs-fail

### DIFF
--- a/app/services/sync_service/assets.rb
+++ b/app/services/sync_service/assets.rb
@@ -49,7 +49,7 @@ module SyncService
       batch_imported = 0
 
       batch.each do |row|
-        next if row["Path"].include?(".DS_Store") || row["Path"].include?("thumbs.db")
+        next if row["Path"].include?(".DS_Store") || row["Path"].include?("thumbs.db") || row["Path"].include?(".apdisk")
 
         # Ensure directory structure exists before bulk insert
         isilon_path = set_full_path(row["Path"])


### PR DESCRIPTION
An apdisk file stores information about mounted folders from Windows network.