### PR TITLE
IMT-135-ingest-larger-volume-data-to-test-performance-and-usability

### DIFF
--- a/app/services/sync_service/assets.rb
+++ b/app/services/sync_service/assets.rb
@@ -20,7 +20,7 @@ module SyncService
 
     def sync
       imported = 0
-      batch_size = 1000
+      batch_size = 100
 
       stdout_and_log("Starting CSV processing with batch size: #{batch_size}")
 
@@ -37,9 +37,6 @@ module SyncService
       end
 
       stdout_and_log("Imported #{imported} IsilonAsset records.")
-
-      # Post-processing: Apply Rule 4 for TIFF file count comparisons
-      apply_rule_4_post_processing
     end
 
     private
@@ -49,7 +46,7 @@ module SyncService
       batch_imported = 0
 
       batch.each do |row|
-        next if row["Path"].include?(".DS_Store") || row["Path"].include?("thumbs.db")
+        next if row["Path"].include?(".DS_Store") || row["Path"].include?("thumbs.db") || row["Path"].include?(".apdisk")
 
         # Ensure directory structure exists before bulk insert
         isilon_path = set_full_path(row["Path"])
@@ -256,87 +253,7 @@ module SyncService
       path_segments.any? { |segment| segment.downcase.include?("delete") }
     end
 
-    def apply_rule_4_post_processing
-      stdout_and_log("Starting Rule 4 post-processing for PROCESSED/UNPROCESSED TIFF comparison...")
 
-      # Use database queries instead of re-reading CSV for better performance
-      parent_dirs_with_counts = find_parent_dirs_with_matching_tiff_counts
-
-      # Update unprocessed TIFFs in bulk
-      parent_dirs_with_counts.each do |parent_info|
-        mark_unprocessed_tiffs_as_dont_migrate(parent_info[:parent_dir], parent_info[:count])
-      end
-
-      stdout_and_log("Rule 4 post-processing completed.")
-    end
-
-    def find_parent_dirs_with_matching_tiff_counts
-      tiff_assets = IsilonAsset.joins(parent_folder: :volume)
-                              .where(parent_folder: { volume: @parent_volume })
-                              .where("LOWER(isilon_path) LIKE '%/deposit/%'")
-                              .where("LOWER(isilon_path) NOT LIKE '%/deposit/scrc accessions%'")
-                              .where("LOWER(file_type) LIKE '%tiff%' OR LOWER(isilon_path) LIKE '%.tiff' OR LOWER(isilon_path) LIKE '%.tif'")
-                              .where("LOWER(isilon_path) LIKE '%/processed/%' OR LOWER(isilon_path) LIKE '%/unprocessed/%' OR LOWER(isilon_path) LIKE '%/raw/%'")
-
-      # Group assets by parent directory and subdirectory type
-      parent_dir_analysis = {}
-
-      tiff_assets.find_each do |asset|
-        parent_dir = extract_parent_directory(asset.isilon_path)
-        subdirectory_type = extract_subdirectory_type(asset.isilon_path)
-
-        next unless parent_dir && subdirectory_type
-
-        parent_dir_analysis[parent_dir] ||= { processed: 0, unprocessed: 0 }
-        parent_dir_analysis[parent_dir][subdirectory_type] += 1
-      end
-
-      # Return only parent directories where processed count = unprocessed count
-      parent_dir_analysis.filter_map do |parent_dir, counts|
-        if counts[:processed] > 0 && counts[:unprocessed] > 0 && counts[:processed] == counts[:unprocessed]
-          {
-            parent_dir: parent_dir,
-            count: counts[:processed]
-          }
-        end
-      end
-    end
-
-    def extract_parent_directory(isilon_path)
-      path_lower = isilon_path.downcase
-
-      if path_lower.include?("/processed/")
-        isilon_path.split("/processed/").first
-      elsif path_lower.include?("/unprocessed/")
-        isilon_path.split("/unprocessed/").first
-      elsif path_lower.include?("/raw/")
-        isilon_path.split("/raw/").first
-      end
-    end
-
-    def extract_subdirectory_type(isilon_path)
-      path_lower = isilon_path.downcase
-
-      if path_lower.include?("/processed/")
-        :processed
-      elsif path_lower.include?("/unprocessed/") || path_lower.include?("/raw/")
-        :unprocessed
-      end
-    end
-
-    def mark_unprocessed_tiffs_as_dont_migrate(parent_dir, count)
-      dont_migrate_status = MigrationStatus.find_by(name: "Don't migrate")
-
-      # Bulk update all unprocessed TIFFs in this parent directory
-      updated_count = IsilonAsset.joins(parent_folder: :volume)
-        .where(parent_folder: { volume: @parent_volume })
-        .where("isilon_path LIKE ?", "#{parent_dir}/%")
-        .where("(LOWER(isilon_path) LIKE '%/unprocessed/%' OR LOWER(isilon_path) LIKE '%/raw/%')")
-        .where("(LOWER(file_type) LIKE '%tiff%' OR LOWER(isilon_path) LIKE '%.tiff' OR LOWER(isilon_path) LIKE '%.tif')")
-        .update_all(migration_status_id: dont_migrate_status.id)
-
-      stdout_and_log("Rule 4 post-processing: Marked #{updated_count} unprocessed TIFFs as 'Don't migrate' in #{parent_dir} (#{count} processed = #{count} unprocessed)")
-    end
 
     def stdout_and_log(message, level: :info)
       # Toggle for batch processing visibility

--- a/app/services/sync_service/tiffs.rb
+++ b/app/services/sync_service/tiffs.rb
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+
+require "logger"
+require "ostruct"
+
+module SyncService
+  class Tiffs
+    def self.call(volume_name: nil)
+      new(volume_name: volume_name).process
+    end
+
+    def initialize(volume_name: nil)
+      @volume_name = volume_name
+      @log = Logger.new("log/isilon-post-processing.log")
+      @stdout = Logger.new($stdout)
+
+      if @volume_name
+        @parent_volume = Volume.find_by(name: @volume_name)
+        raise ArgumentError, "Volume '#{@volume_name}' not found" unless @parent_volume
+        stdout_and_log("Starting post-processing for volume: #{@volume_name}")
+      else
+        @parent_volume = nil  # Will process all volumes
+        stdout_and_log("Starting post-processing for all volumes")
+      end
+    end
+
+    def process
+      stdout_and_log("Starting Rule 4 post-processing for TIFF comparison...")
+
+      begin
+        # Use ActiveRecord to find parent directories with matching TIFF counts
+        parent_dirs_with_counts = find_parent_dirs_with_matching_tiff_counts_ar
+
+        stdout_and_log("Found #{parent_dirs_with_counts.size} parent directories with matching TIFF counts")
+
+        # Update unprocessed TIFFs in bulk
+        total_updated = 0
+        parent_dirs_with_counts.each do |parent_info|
+          updated = mark_unprocessed_tiffs_as_dont_migrate(parent_info[:parent_dir], parent_info[:processed_count])
+          total_updated += updated
+        end
+
+        stdout_and_log("Rule 4 post-processing completed. Updated #{total_updated} assets.")
+
+        OpenStruct.new(
+          success?: true,
+          tiff_comparisons_updated: parent_dirs_with_counts.size,
+          migration_statuses_updated: total_updated,
+          error_message: nil
+        )
+      rescue => e
+        error_msg = "Post-processing failed: #{e.message}"
+        stdout_and_log(error_msg, level: :error)
+
+        OpenStruct.new(
+          success?: false,
+          tiff_comparisons_updated: 0,
+          migration_statuses_updated: 0,
+          error_message: error_msg
+        )
+      end
+    end
+
+    private
+
+    def find_parent_dirs_with_matching_tiff_counts_ar
+      # Base query for all TIFF assets in deposit folders (excluding scrc accessions)
+      base_query = build_base_tiff_query
+
+      # Get all matching assets and group them in Ruby
+      assets = base_query.pluck(:isilon_path)
+
+      # Group assets by parent directory and classify as processed/unprocessed
+      parent_dir_stats = {}
+
+      assets.each do |path|
+        parent_dir = extract_parent_directory(path)
+        next unless parent_dir
+
+        subdirectory_type = classify_subdirectory_type(path)
+        next unless subdirectory_type
+
+        parent_dir_stats[parent_dir] ||= { processed: 0, unprocessed: 0 }
+        parent_dir_stats[parent_dir][subdirectory_type.to_sym] += 1
+      end
+
+      # Filter to only include directories where processed count equals unprocessed count
+      # and both counts are > 0
+      matching_dirs = parent_dir_stats.select do |parent_dir, counts|
+        counts[:processed] > 0 &&
+        counts[:unprocessed] > 0 &&
+        counts[:processed] == counts[:unprocessed]
+      end
+
+      # Convert to the expected format
+      matching_dirs.map do |parent_dir, counts|
+        {
+          parent_dir: parent_dir,
+          processed_count: counts[:processed],
+          unprocessed_count: counts[:unprocessed]
+        }
+      end
+    end
+
+    def build_base_tiff_query
+      # Start with IsilonAsset, join to get volume info if needed
+      query = IsilonAsset.joins(parent_folder: :volume)
+
+      # Filter to only TIFF files
+      query = query.where(
+        "LOWER(file_type) LIKE ? OR LOWER(isilon_path) LIKE ? OR LOWER(isilon_path) LIKE ?",
+        "%tiff%", "%.tiff", "%.tif"
+      )
+
+      # Filter to deposit folders, excluding scrc accessions
+      query = query.where("LOWER(isilon_path) LIKE ?", "%/deposit/%")
+      query = query.where("LOWER(isilon_path) NOT LIKE ?", "%/deposit/scrc accessions%")
+
+      # Filter to processed, unprocessed, or raw subdirectories
+      query = query.where(
+        "LOWER(isilon_path) LIKE ? OR LOWER(isilon_path) LIKE ? OR LOWER(isilon_path) LIKE ?",
+        "%/processed/%", "%/unprocessed/%", "%/raw/%"
+      )
+
+      # Add volume filter if processing specific volume
+      query = query.where(parent_folder: { volume: @parent_volume }) if @parent_volume
+
+      query
+    end
+
+    def extract_parent_directory(path)
+      # Extract the parent directory before /processed/, /unprocessed/, or /raw/
+      case path.downcase
+      when /^(.+)\/processed\//
+        $1
+      when /^(.+)\/unprocessed\//
+        $1
+      when /^(.+)\/raw\//
+        $1
+      else
+        nil
+      end
+    end
+
+    def classify_subdirectory_type(path)
+      case path.downcase
+      when /\/processed\//
+        "processed"
+      when /\/unprocessed\//, /\/raw\//
+        "unprocessed"
+      else
+        nil
+      end
+    end
+
+    def mark_unprocessed_tiffs_as_dont_migrate(parent_dir, count)
+      dont_migrate_status = MigrationStatus.find_by(name: "Don't migrate")
+
+      unless dont_migrate_status
+        stdout_and_log("ERROR: 'Don't migrate' status not found", level: :error)
+        return 0
+      end
+
+      # Build query for unprocessed TIFFs in this parent directory
+      query = IsilonAsset.joins(parent_folder: :volume)
+        .where("isilon_path LIKE ?", "#{parent_dir}/%")
+        .where("(LOWER(isilon_path) LIKE '%/unprocessed/%' OR LOWER(isilon_path) LIKE '%/raw/%')")
+        .where("(LOWER(file_type) LIKE '%tiff%' OR LOWER(isilon_path) LIKE '%.tiff' OR LOWER(isilon_path) LIKE '%.tif')")
+
+      # Add volume filter if processing specific volume
+      query = query.where(parent_folder: { volume: @parent_volume }) if @parent_volume
+
+      updated_count = query.update_all(migration_status_id: dont_migrate_status.id)
+
+      stdout_and_log("Rule 4: Marked #{updated_count} unprocessed TIFFs as 'Don't migrate' in #{parent_dir} (#{count} processed = #{count} unprocessed)")
+
+      updated_count
+    end
+
+    def stdout_and_log(message, level: :info)
+      @log.send(level, message)
+      @stdout.send(level, message)
+    end
+  end
+end

--- a/spec/services/sync_service/tiffs_spec.rb
+++ b/spec/services/sync_service/tiffs_spec.rb
@@ -1,0 +1,271 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SyncService::Tiffs, type: :service do
+  let!(:deposit_volume) { FactoryBot.create(:volume, name: "deposit") }
+  let!(:media_volume) { FactoryBot.create(:volume, name: "media-repository") }
+  let!(:default_migration_status) { FactoryBot.create(:migration_status, :default) }
+  let!(:dont_migrate_status) { FactoryBot.create(:migration_status, :dont_migrate) }
+
+  describe '.call' do
+    it 'creates new instance and calls process' do
+      expect_any_instance_of(described_class).to receive(:process)
+      described_class.call(volume_name: "deposit")
+    end
+  end
+
+  describe '#initialize' do
+    context 'with valid volume name' do
+      it 'sets up for specific volume' do
+        service = described_class.new(volume_name: "deposit")
+        expect(service.instance_variable_get(:@volume_name)).to eq("deposit")
+        expect(service.instance_variable_get(:@parent_volume)).to eq(deposit_volume)
+      end
+    end
+
+    context 'with no volume name' do
+      it 'sets up for all volumes' do
+        service = described_class.new
+        expect(service.instance_variable_get(:@volume_name)).to be_nil
+        expect(service.instance_variable_get(:@parent_volume)).to be_nil
+      end
+    end
+
+    context 'with invalid volume name' do
+      it 'raises ArgumentError' do
+        expect {
+          described_class.new(volume_name: "nonexistent")
+        }.to raise_error(ArgumentError, "Volume 'nonexistent' not found")
+      end
+    end
+  end
+
+  describe '#process' do
+    # Set up test data with folder structure
+    let!(:project1_folder) { FactoryBot.create(:isilon_folder, volume: deposit_volume, full_path: "/deposit/project1") }
+    let!(:project1_processed) { FactoryBot.create(:isilon_folder, volume: deposit_volume, full_path: "/deposit/project1/processed", parent_folder: project1_folder) }
+    let!(:project1_unprocessed) { FactoryBot.create(:isilon_folder, volume: deposit_volume, full_path: "/deposit/project1/unprocessed", parent_folder: project1_folder) }
+
+    let!(:project2_folder) { FactoryBot.create(:isilon_folder, volume: deposit_volume, full_path: "/deposit/project2") }
+    let!(:project2_processed) { FactoryBot.create(:isilon_folder, volume: deposit_volume, full_path: "/deposit/project2/processed", parent_folder: project2_folder) }
+    let!(:project2_raw) { FactoryBot.create(:isilon_folder, volume: deposit_volume, full_path: "/deposit/project2/raw", parent_folder: project2_folder) }
+
+    # Create TIFF assets - Project 1: Equal counts (2 processed, 2 unprocessed)
+    let!(:project1_assets) do
+      [
+        FactoryBot.create(:isilon_asset, parent_folder: project1_processed, isilon_path: "/deposit/project1/processed/image001.tiff", file_type: "TIFF", migration_status: default_migration_status),
+        FactoryBot.create(:isilon_asset, parent_folder: project1_processed, isilon_path: "/deposit/project1/processed/image002.tiff", file_type: "TIFF", migration_status: default_migration_status),
+        FactoryBot.create(:isilon_asset, parent_folder: project1_unprocessed, isilon_path: "/deposit/project1/unprocessed/image001.tiff", file_type: "TIFF", migration_status: default_migration_status),
+        FactoryBot.create(:isilon_asset, parent_folder: project1_unprocessed, isilon_path: "/deposit/project1/unprocessed/image002.tiff", file_type: "TIFF", migration_status: default_migration_status)
+      ]
+    end
+
+    # Create TIFF assets - Project 2: Unequal counts (1 processed, 2 raw)
+    let!(:project2_assets) do
+      [
+        FactoryBot.create(:isilon_asset, parent_folder: project2_processed, isilon_path: "/deposit/project2/processed/scan001.tiff", file_type: "TIFF", migration_status: default_migration_status),
+        FactoryBot.create(:isilon_asset, parent_folder: project2_raw, isilon_path: "/deposit/project2/raw/scan001.tiff", file_type: "TIFF", migration_status: default_migration_status),
+        FactoryBot.create(:isilon_asset, parent_folder: project2_raw, isilon_path: "/deposit/project2/raw/scan002.tiff", file_type: "TIFF", migration_status: default_migration_status)
+      ]
+    end
+
+    context 'when processing all volumes' do
+      it 'marks unprocessed TIFFs as "Don\'t migrate" when counts match' do
+        service = described_class.new
+        result = service.process
+
+        expect(result.success?).to be true
+        expect(result.tiff_comparisons_updated).to eq(1)  # Only project1 has matching counts
+        expect(result.migration_statuses_updated).to eq(2)  # 2 unprocessed TIFFs updated
+
+        # Project 1: 2 processed, 2 unprocessed - should mark unprocessed as "Don't migrate"
+        project1_unprocessed = IsilonAsset.where(isilon_path: [
+          "/deposit/project1/unprocessed/image001.tiff",
+          "/deposit/project1/unprocessed/image002.tiff"
+        ])
+        expect(project1_unprocessed.all? { |asset| asset.migration_status == dont_migrate_status }).to be true
+
+        # Project 2: 1 processed, 2 raw - should NOT change (counts don't match)
+        project2_raw = IsilonAsset.where(isilon_path: [
+          "/deposit/project2/raw/scan001.tiff",
+          "/deposit/project2/raw/scan002.tiff"
+        ])
+        expect(project2_raw.all? { |asset| asset.migration_status == default_migration_status }).to be true
+      end
+    end
+
+    context 'when processing specific volume' do
+      it 'only processes TIFFs in the specified volume' do
+        service = described_class.new(volume_name: "deposit")
+        result = service.process
+
+        expect(result.success?).to be true
+        expect(result.tiff_comparisons_updated).to eq(1)
+        expect(result.migration_statuses_updated).to eq(2)
+      end
+    end
+
+    context 'when no matching TIFF patterns found' do
+      it 'completes successfully with zero updates' do
+        # Remove all TIFF assets
+        IsilonAsset.destroy_all
+
+        service = described_class.new(volume_name: "deposit")
+        result = service.process
+
+        expect(result.success?).to be true
+        expect(result.tiff_comparisons_updated).to eq(0)
+        expect(result.migration_statuses_updated).to eq(0)
+      end
+    end
+
+    context 'when "Don\'t migrate" status is missing' do
+      before { dont_migrate_status.destroy }
+
+      it 'completes successfully but logs error and updates nothing' do
+        service = described_class.new(volume_name: "deposit")
+
+        # Allow all normal log messages to pass through
+        allow(service).to receive(:stdout_and_log).and_call_original
+
+        # Expect the specific error message to be logged at least once
+        expect(service).to receive(:stdout_and_log).with(
+          "ERROR: 'Don't migrate' status not found",
+          level: :error
+        ).at_least(:once).and_call_original
+
+        result = service.process
+
+        # Service completes successfully but doesn't update anything
+        expect(result.success?).to be true
+        expect(result.migration_statuses_updated).to eq(0)
+      end
+    end
+  end
+
+  describe '#extract_parent_directory' do
+    let(:service) { described_class.new }
+
+    it 'extracts parent from processed path' do
+      path = "/deposit/project1/processed/image.tiff"
+      result = service.send(:extract_parent_directory, path)
+      expect(result).to eq("/deposit/project1")
+    end
+
+    it 'extracts parent from unprocessed path' do
+      path = "/deposit/project2/unprocessed/scan.tiff"
+      result = service.send(:extract_parent_directory, path)
+      expect(result).to eq("/deposit/project2")
+    end
+
+    it 'extracts parent from raw path' do
+      path = "/deposit/project3/raw/file.tiff"
+      result = service.send(:extract_parent_directory, path)
+      expect(result).to eq("/deposit/project3")
+    end
+
+    it 'returns nil for invalid path' do
+      path = "/deposit/project4/other/file.tiff"
+      result = service.send(:extract_parent_directory, path)
+      expect(result).to be_nil
+    end
+
+    it 'handles case insensitive matching' do
+      path = "/deposit/PROJECT1/PROCESSED/image.tiff"
+      result = service.send(:extract_parent_directory, path)
+      expect(result).to eq("/deposit/project1")  # Method converts to lowercase for matching
+    end
+  end
+
+  describe '#classify_subdirectory_type' do
+    let(:service) { described_class.new }
+
+    it 'classifies processed directory' do
+      path = "/deposit/project1/processed/image.tiff"
+      result = service.send(:classify_subdirectory_type, path)
+      expect(result).to eq("processed")
+    end
+
+    it 'classifies unprocessed directory' do
+      path = "/deposit/project1/unprocessed/image.tiff"
+      result = service.send(:classify_subdirectory_type, path)
+      expect(result).to eq("unprocessed")
+    end
+
+    it 'classifies raw directory as unprocessed' do
+      path = "/deposit/project1/raw/image.tiff"
+      result = service.send(:classify_subdirectory_type, path)
+      expect(result).to eq("unprocessed")
+    end
+
+    it 'returns nil for other directories' do
+      path = "/deposit/project1/other/image.tiff"
+      result = service.send(:classify_subdirectory_type, path)
+      expect(result).to be_nil
+    end
+  end
+
+  describe '#build_base_tiff_query' do
+    let(:service) { described_class.new }
+    let!(:test_folder) { FactoryBot.create(:isilon_folder, volume: deposit_volume, full_path: "/deposit/test/processed") }
+
+    it 'includes TIFF files by extension and file_type' do
+      # Create test assets
+      tiff_asset1 = FactoryBot.create(:isilon_asset, parent_folder: test_folder, isilon_path: "/deposit/test/processed/image.tiff")
+      tiff_asset2 = FactoryBot.create(:isilon_asset, parent_folder: test_folder, isilon_path: "/deposit/test/processed/image.tif")
+      tiff_asset3 = FactoryBot.create(:isilon_asset, parent_folder: test_folder, isilon_path: "/deposit/test/processed/image.jpg", file_type: "TIFF Image")
+      pdf_asset = FactoryBot.create(:isilon_asset, parent_folder: test_folder, isilon_path: "/deposit/test/processed/doc.pdf")
+
+      query = service.send(:build_base_tiff_query)
+      results = query.pluck(:isilon_path)
+
+      expect(results).to include(tiff_asset1.isilon_path)
+      expect(results).to include(tiff_asset2.isilon_path)
+      expect(results).to include(tiff_asset3.isilon_path)
+      expect(results).not_to include(pdf_asset.isilon_path)
+    end
+
+    it 'filters to deposit folders' do
+      other_folder = FactoryBot.create(:isilon_folder, volume: deposit_volume, full_path: "/other/test/processed")
+
+      deposit_asset = FactoryBot.create(:isilon_asset, parent_folder: test_folder, isilon_path: "/deposit/test/processed/image.tiff")
+      other_asset = FactoryBot.create(:isilon_asset, parent_folder: other_folder, isilon_path: "/other/test/processed/image.tiff")
+
+      query = service.send(:build_base_tiff_query)
+      results = query.pluck(:isilon_path)
+
+      expect(results).to include(deposit_asset.isilon_path)
+      expect(results).not_to include(other_asset.isilon_path)
+    end
+
+    it 'excludes scrc accessions' do
+      scrc_folder = FactoryBot.create(:isilon_folder, volume: deposit_volume, full_path: "/deposit/scrc accessions/processed")
+
+      regular_asset = FactoryBot.create(:isilon_asset, parent_folder: test_folder, isilon_path: "/deposit/regular/processed/image.tiff")
+      scrc_asset = FactoryBot.create(:isilon_asset, parent_folder: scrc_folder, isilon_path: "/deposit/scrc accessions/processed/image.tiff")
+
+      query = service.send(:build_base_tiff_query)
+      results = query.pluck(:isilon_path)
+
+      expect(results).to include(regular_asset.isilon_path)
+      expect(results).not_to include(scrc_asset.isilon_path)
+    end
+  end
+
+  describe 'error handling' do
+    it 'returns error result when exception occurs' do
+      service = described_class.new(volume_name: "deposit")
+
+      # Simulate an error by stubbing build_base_tiff_query to raise an exception
+      allow(service).to receive(:build_base_tiff_query).and_raise(StandardError.new("Database error"))
+
+      result = service.process
+
+      expect(result.success?).to be false
+      expect(result.error_message).to include("Post-processing failed: Database error")
+      expect(result.tiff_comparisons_updated).to eq(0)
+      expect(result.migration_statuses_updated).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
Separate TIFF post-processing from assets sync and optimize memory usage.

This separation should resolve OOM issues in production by allowing TIFF processing to run independently from the main CSV import, improving scalability and memory efficiency in Kubernetes environments.