### PR TITLE
IMT-135-ingest-larger-volume-data-to-test-performance-and-usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ or
 bundle exec rails "sync:assets[scan_output.applications-backup.csv]"
 ```
 
+* Run TIFF comparison analysis for deduplication (separate from assets sync for memory optimization)
+
+After importing assets, run the TIFF comparison analysis to identify duplicate TIFF files and update migration statuses accordingly. This task processes TIFF files in deposit or media-repository volumes and marks unprocessed duplicates as "Don't migrate" when matching processed versions exist.
+
+`bundle exec rails sync:tiffs[deposit]`
+
+or for media-repository volume:
+
+`bundle exec rails sync:tiffs[media-repository]`
+
+**Note:** This task runs separately from sync:assets to avoid memory issues with large datasets in production Kubernetes environments. It analyzes TIFF files in processed/unprocessed/raw subdirectories.
+
 * Install node packages and JS dependencies
 
 ```bash

--- a/lib/tasks/isilon_import.rake
+++ b/lib/tasks/isilon_import.rake
@@ -6,4 +6,33 @@ namespace :sync do
     args.with_defaults(path: nil)
     SyncService::Assets.call(csv_path: args[:path])
   end
+
+  desc "Process TIFF files for deduplication"
+  task :tiffs, [ :volume_name ] => :environment do |_t, args|
+    unless args[:volume_name]
+      puts "Error: volume_name argument is required"
+      puts "Usage: rake sync:tiffs[deposit] or rake sync:tiffs[media-repository]"
+      exit 1
+    end
+
+    valid_volumes = %w[deposit media-repository]
+    unless valid_volumes.include?(args[:volume_name])
+      puts "Error: volume_name must be one of: #{valid_volumes.join(', ')}"
+      exit 1
+    end
+
+    volume = Volume.find_by(name: args[:volume_name])
+    unless volume
+      puts "Error: Volume '#{args[:volume_name]}' not found in database"
+      exit 1
+    end
+
+    begin
+      SyncService::Tiffs.call(volume_name: args[:volume_name])
+    rescue => e
+      puts "Error during TIFF processing: #{e.message}"
+      puts e.backtrace.first(5).join("\n") if e.backtrace
+      exit 1
+    end
+  end
 end

--- a/spec/tasks/sync_rake_spec.rb
+++ b/spec/tasks/sync_rake_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'sync rake tasks', type: :task do
+  before(:all) do
+    Rake.application.rake_require 'tasks/isilon_import'
+    Rake::Task.define_task(:environment)
+  end
+
+  before(:each) do
+    Rake::Task['sync:tiffs'].reenable if Rake::Task.task_defined?('sync:tiffs')
+    Rake::Task['sync:assets'].reenable if Rake::Task.task_defined?('sync:assets')
+  end
+
+  describe 'sync:tiffs' do
+    let!(:deposit_volume) { create(:volume, name: 'deposit') }
+    let!(:media_volume) { create(:volume, name: 'media-repository') }
+
+    context 'with valid volume argument' do
+      it 'calls SyncService::Tiffs with the correct volume_name' do
+        expect(SyncService::Tiffs).to receive(:call).with(volume_name: 'deposit')
+
+        Rake::Task['sync:tiffs'].invoke('deposit')
+      end
+
+      it 'works with media-repository volume' do
+        expect(SyncService::Tiffs).to receive(:call).with(volume_name: 'media-repository')
+
+        Rake::Task['sync:tiffs'].invoke('media-repository')
+      end
+    end
+
+    context 'with missing volume argument' do
+      it 'exits with error message' do
+        expect { Rake::Task['sync:tiffs'].invoke }.to raise_error(SystemExit) do |error|
+          expect(error.status).to eq(1)
+        end
+      end
+    end
+
+    context 'with invalid volume argument' do
+      it 'exits with error for unknown volume name' do
+        expect { Rake::Task['sync:tiffs'].invoke('invalid-volume') }.to raise_error(SystemExit) do |error|
+          expect(error.status).to eq(1)
+        end
+      end
+    end
+
+    context 'with volume not in database' do
+      it 'exits with error when volume does not exist in database' do
+        expect { Rake::Task['sync:tiffs'].invoke('nonexistent') }.to raise_error(SystemExit) do |error|
+          expect(error.status).to eq(1)
+        end
+      end
+    end
+
+    context 'when service raises an exception' do
+      it 'exits with error and shows backtrace' do
+        allow(SyncService::Tiffs).to receive(:call).and_raise(StandardError.new('Service failed'))
+
+        expect { Rake::Task['sync:tiffs'].invoke('deposit') }.to raise_error(SystemExit) do |error|
+          expect(error.status).to eq(1)
+        end
+      end
+    end
+  end
+
+  describe 'sync:assets' do
+    context 'with csv_path argument' do
+      it 'calls SyncService::Assets with the correct csv_path' do
+        expect(SyncService::Assets).to receive(:call).with(csv_path: '/path/to/file.csv')
+
+        Rake::Task['sync:assets'].invoke('/path/to/file.csv')
+      end
+    end
+
+    context 'without csv_path argument' do
+      it 'calls SyncService::Assets with nil csv_path' do
+        expect(SyncService::Assets).to receive(:call).with(csv_path: nil)
+
+        Rake::Task['sync:assets'].invoke
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes task call and adds tests to ensure functionality of task call not just the service itself.

Also updates the readme to add the tiff comparison task, now separate from assets sync.