### PR TITLE
add manual bulk updates

### DIFF
--- a/app/services/sync_service/bulk_update.rb
+++ b/app/services/sync_service/bulk_update.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module SyncService
+  class BulkUpdate
+    BATCH_SIZE = 10_000
+
+    Result = Struct.new(
+      :updated_count,
+      :folder_count,
+      :volume_id,
+      :full_path,
+      keyword_init: true
+    )
+
+    def self.call(volume_id:, full_path:, updates: {})
+      new(volume_id: volume_id, full_path: full_path, updates: updates).call
+    end
+
+    def initialize(volume_id:, full_path:, updates:)
+      @volume_id = volume_id
+      @full_path = full_path.to_s.strip
+      @updates = updates
+    end
+
+    def call
+      validate_updates!
+
+      folder = IsilonFolder.find_by!(volume_id: @volume_id, full_path: @full_path)
+      descendant_folder_ids = descendant_folder_ids_for(folder.id)
+      updates = update_attributes
+      updated_count = 0
+
+      IsilonAsset.where(parent_folder_id: descendant_folder_ids).in_batches(of: BATCH_SIZE) do |batch|
+        updated_count += batch.update_all(updates)
+      end
+
+      Result.new(
+        updated_count: updated_count,
+        folder_count: descendant_folder_ids.length,
+        volume_id: folder.volume_id,
+        full_path: folder.full_path
+      )
+    end
+
+    private
+
+    def validate_updates!
+      return if @updates.present?
+
+      raise ArgumentError, "At least one update field is required"
+    end
+
+    def update_attributes
+      {}.tap do |updates|
+        updates[:migration_status_id] = validated_migration_status_id if @updates.key?(:migration_status_id)
+        updates[:assigned_to_id] = validated_assigned_to_id if @updates.key?(:assigned_to_id)
+      end
+    end
+
+    def validated_migration_status_id
+      return nil if @updates[:migration_status_id].nil?
+
+      MigrationStatus.find(@updates[:migration_status_id]).id
+    end
+
+    def validated_assigned_to_id
+      return nil if @updates[:assigned_to_id].nil?
+
+      User.find(@updates[:assigned_to_id]).id
+    end
+
+    def descendant_folder_ids_for(folder_id)
+      sql = <<~SQL.squish
+        WITH RECURSIVE descendants AS (
+          SELECT id
+          FROM isilon_folders
+          WHERE id = #{folder_id.to_i} AND volume_id = #{@volume_id.to_i}
+          UNION ALL
+          SELECT child.id
+          FROM isilon_folders child
+          INNER JOIN descendants parent_descendants ON child.parent_folder_id = parent_descendants.id
+          WHERE child.volume_id = #{@volume_id.to_i}
+        )
+        SELECT id FROM descendants
+      SQL
+
+      ActiveRecord::Base.connection.exec_query(sql).rows.flatten.map(&:to_i).uniq
+    end
+  end
+end

--- a/spec/services/sync_service/bulk_update_spec.rb
+++ b/spec/services/sync_service/bulk_update_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SyncService::BulkUpdate, type: :service do
+  let!(:volume) { create(:volume, name: "Deposit") }
+  let!(:other_volume) { create(:volume, name: "Media-Repository") }
+
+  let!(:root_folder) do
+    create(:isilon_folder, volume: volume, full_path: "/collections/root")
+  end
+  let!(:child_folder) do
+    create(:isilon_folder, volume: volume, parent_folder: root_folder, full_path: "/collections/root/child")
+  end
+  let!(:grandchild_folder) do
+    create(:isilon_folder, volume: volume, parent_folder: child_folder, full_path: "/collections/root/child/grandchild")
+  end
+  let!(:sibling_folder) do
+    create(:isilon_folder, volume: volume, full_path: "/collections/sibling")
+  end
+  let!(:same_path_other_volume) do
+    create(:isilon_folder, volume: other_volume, full_path: "/collections/root")
+  end
+
+  let!(:status_one) { create(:migration_status, name: "Needs Review") }
+  let!(:status_two) { create(:migration_status, name: "Migrated") }
+  let!(:user_one) { create(:user, name: "User One") }
+  let!(:user_two) { create(:user, name: "User Two") }
+
+  let!(:root_asset) do
+    create(:isilon_asset, parent_folder: root_folder, migration_status: status_one, assigned_to: user_one)
+  end
+  let!(:child_asset) do
+    create(:isilon_asset, parent_folder: child_folder, migration_status: status_one, assigned_to: nil)
+  end
+  let!(:grandchild_asset) do
+    create(:isilon_asset, parent_folder: grandchild_folder, migration_status: status_one, assigned_to: nil)
+  end
+  let!(:sibling_asset) do
+    create(:isilon_asset, parent_folder: sibling_folder, migration_status: status_one, assigned_to: user_one)
+  end
+  let!(:other_volume_asset) do
+    create(:isilon_asset, parent_folder: same_path_other_volume, migration_status: status_one, assigned_to: user_one)
+  end
+
+  describe ".call" do
+    it "updates assets in the selected folder and all descendant folders" do
+      result = described_class.call(
+        volume_id: volume.id,
+        full_path: root_folder.full_path,
+        updates: {
+          migration_status_id: status_two.id,
+          assigned_to_id: user_two.id
+        }
+      )
+
+      expect(result.updated_count).to eq(3)
+      expect(result.folder_count).to eq(3)
+      expect(result.volume_id).to eq(volume.id)
+      expect(result.full_path).to eq(root_folder.full_path)
+
+      expect(root_asset.reload.migration_status).to eq(status_two)
+      expect(child_asset.reload.migration_status).to eq(status_two)
+      expect(grandchild_asset.reload.migration_status).to eq(status_two)
+
+      expect(root_asset.reload.assigned_to).to eq(user_two)
+      expect(child_asset.reload.assigned_to).to eq(user_two)
+      expect(grandchild_asset.reload.assigned_to).to eq(user_two)
+
+      expect(sibling_asset.reload.migration_status).to eq(status_one)
+      expect(other_volume_asset.reload.migration_status).to eq(status_one)
+    end
+
+    it "updates only the requested field when one field is omitted" do
+      described_class.call(
+        volume_id: volume.id,
+        full_path: root_folder.full_path,
+        updates: {
+          assigned_to_id: user_two.id
+        }
+      )
+
+      expect(root_asset.reload.assigned_to).to eq(user_two)
+      expect(child_asset.reload.assigned_to).to eq(user_two)
+      expect(grandchild_asset.reload.assigned_to).to eq(user_two)
+
+      expect(root_asset.reload.migration_status).to eq(status_one)
+      expect(child_asset.reload.migration_status).to eq(status_one)
+      expect(grandchild_asset.reload.migration_status).to eq(status_one)
+    end
+
+    it "supports clearing assigned user across descendant assets" do
+      child_asset.update!(assigned_to: user_one)
+      grandchild_asset.update!(assigned_to: user_one)
+
+      described_class.call(
+        volume_id: volume.id,
+        full_path: root_folder.full_path,
+        updates: {
+          assigned_to_id: nil
+        }
+      )
+
+      expect(root_asset.reload.assigned_to).to be_nil
+      expect(child_asset.reload.assigned_to).to be_nil
+      expect(grandchild_asset.reload.assigned_to).to be_nil
+    end
+
+    it "raises when the folder cannot be found within the selected volume" do
+      expect {
+        described_class.call(
+          volume_id: volume.id,
+          full_path: "/collections/missing",
+          updates: {
+            migration_status_id: status_two.id
+          }
+        )
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "raises when no update fields are provided" do
+      expect {
+        described_class.call(
+          volume_id: volume.id,
+          full_path: root_folder.full_path,
+          updates: {}
+        )
+      }.to raise_error(ArgumentError, /At least one update field is required/)
+    end
+  end
+end


### PR DESCRIPTION
First part manual update. Second part admin ui updateable (still to come). 

Run in rails console:

`volume = Volume.find_by!(name: "volume name to apply updates")
full_path = "path to apply changes in"

status = MigrationStatus.find_by!(name: "migration status to apply in bulk, if needed")
user = User.find_by!(email: "email value for assigned_to, if needed")

SyncService::BulkUpdate.call(
  volume_id: volume.id,
  full_path: full_path,
  updates: {
    migration_status_id: status.id,
    assigned_to_id: user.id
  }
)`