### PR TITLE
Imt 207 filters return all matches

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -349,6 +349,11 @@ div.wunderbaum .wb-title .wb-badge {
   top: -2px;
 }
 
+div.wunderbaum .wb-title .wb-badge.wb-match-badge {
+  background-color: #16a34a;
+  color: #ffffff;
+}
+
 .dashboard-title {
   font-weight: 400;
 }

--- a/app/controllers/volumes_controller.rb
+++ b/app/controllers/volumes_controller.rb
@@ -32,11 +32,18 @@ class VolumesController < ApplicationController
 
   def file_tree_folders_search
     q = params[:q].to_s.strip
-    return render(json: []) if q.blank?
+    assigned_to = params[:assigned_to].presence
+    return render(json: []) if q.blank? && assigned_to.blank?
 
-    folders = @volume.isilon_folders
-                    .where("LOWER(full_path) LIKE ?", "%#{q.downcase}%")
-                    .includes(:parent_folder)
+    folders = @volume.isilon_folders.includes(:parent_folder)
+
+    folders = folders.where("LOWER(full_path) LIKE ?", "%#{q.downcase}%") if q.present?
+
+    if assigned_to.present? && assigned_to != "unassigned"
+      folders = folders.where(assigned_to_id: assigned_to)
+    end
+
+    folders = folders.where(assigned_to_id: nil) if assigned_to == "unassigned"
 
     render json: folders.map { |folder| FileTreeSearchResultSerializer.new(folder).as_json }
   end
@@ -51,20 +58,53 @@ class VolumesController < ApplicationController
 
     # Column filters
     scope = scope.where(migration_status: params[:migration_status]) if params[:migration_status].present?
-    scope = scope.where(assigned_to_id: params[:assigned_to]) if params[:assigned_to].present? && params[:assigned_to] != "unassigned"
-    scope = scope.where(file_type: params[:file_type]) if params[:file_type].present?
-    scope = scope.where(contentdm_collection_id: params[:contentdm_collection_id]) if params[:contentdm_collection_id].present?
-    scope = scope.where(aspace_collection_id: params[:aspace_collection_id]) if params[:aspace_collection_id].present?
-    scope = scope.where(aspace_linking_status: ActiveModel::Type::Boolean.new.cast(params[:aspace_linking_status])) if params.key?(:aspace_linking_status)
-    scope = scope.where(has_duplicates: ActiveModel::Type::Boolean.new.cast(params[:is_duplicate])) if params.key?(:is_duplicate)
 
-    # Handle unassigned users (assigned_to = nil)
-    if params[:assigned_to] == "unassigned"
-      scope = scope.where(assigned_to_id: nil)
+    if params[:assigned_to].present? && params[:assigned_to] != "unassigned"
+      scope = scope.where(assigned_to_id: params[:assigned_to])
     end
 
-    assets = scope.includes(parent_folder: :parent_folder).limit(500)
-    render json: assets.map { |asset| FileTreeSearchResultSerializer.new(asset).as_json }
+    if params[:file_type].present?
+      normalized_file_type = params[:file_type].to_s.strip.downcase
+
+      scope = scope.where(
+        "LOWER(TRIM(isilon_assets.file_type)) = ?",
+        normalized_file_type
+      )
+    end
+
+    if params[:contentdm_collection_id].present?
+      scope = scope.where(contentdm_collection_id: params[:contentdm_collection_id])
+    end
+
+    if params[:aspace_collection_id].present?
+      scope = scope.where(aspace_collection_id: params[:aspace_collection_id])
+    end
+
+    if params.key?(:aspace_linking_status)
+      value = ActiveModel::Type::Boolean.new.cast(params[:aspace_linking_status])
+      scope = scope.where(aspace_linking_status: value)
+    end
+
+    if params.key?(:is_duplicate)
+      value = ActiveModel::Type::Boolean.new.cast(params[:is_duplicate])
+      scope = scope.where(has_duplicates: value)
+    end
+
+    # Handle unassigned users (assigned_to = nil)
+    scope = scope.where(assigned_to_id: nil) if params[:assigned_to] == "unassigned"
+    total_count = scope.count
+
+    assets = scope.includes(parent_folder: :parent_folder)
+
+    tree_nodes = assets.map do |asset|
+      FileTreeSearchResultSerializer.new(asset).as_json
+    end
+
+    render json: {
+      results: tree_nodes,
+      total_count: total_count,
+      returned_count: tree_nodes.size
+    }
   end
 
   def file_tree_updates

--- a/app/javascript/controllers/wunderbaum_controller.js
+++ b/app/javascript/controllers/wunderbaum_controller.js
@@ -15,6 +15,7 @@ export default class extends Controller {
   folderCache = new Map();
   assetCache = new Map();
   loadedFolders = new Set();
+  folderMatchCounts = new Map();
 
   inflightControllers = new Set();
   _filterTimer = null;
@@ -268,14 +269,34 @@ export default class extends Controller {
           if (isFolder) {
             titleElem.textContent = node.title || "";
 
-            const count = node.data?.descendant_assets_count;
-            if (count != null) {
-              const badge = document.createElement("span");
-              badge.className = "wb-badge";
-              badge.textContent = count;
-              badge.title = `${count} assets`;
-              badge.style.marginLeft = "6px";
-              titleElem.appendChild(badge);
+            const totalCount = node.data?.descendant_assets_count;
+
+            if (totalCount != null) {
+              const totalBadge = document.createElement("span");
+              totalBadge.className = "wb-badge";
+              totalBadge.textContent = totalCount;
+              totalBadge.title = `${totalCount} total assets`;
+              totalBadge.style.marginLeft = "6px";
+              titleElem.appendChild(totalBadge);
+            }
+
+            const folderKey = String(
+              node.key ??
+              node.data?.key ??
+              node.data?.id
+            );
+
+            const matchCount =
+              this.folderMatchCounts.get(folderKey) || 0;
+
+            if (this._hasActiveFilter() && matchCount > 0) {
+              const matchBadge = document.createElement("span");
+              matchBadge.className = "wb-badge wb-match-badge";
+              matchBadge.textContent = `${matchCount} matches`;
+              matchBadge.title =
+                `${matchCount} matching assets in this folder and its subfolders`;
+              matchBadge.style.marginLeft = "6px";
+              titleElem.appendChild(matchBadge);
             }
           } else {
             titleElem.innerHTML =
@@ -559,53 +580,134 @@ export default class extends Controller {
   async _runDeepFilter(raw) {
     this._cancelActiveSearch();
     this._cancelInflight();
+
     const mySeq = ++this._filterSeq;
+
     this.loadedFolders.clear();
     this.assetsLoadedFor.clear();
     this.assetCache.clear();
+    this.folderMatchCounts.clear();
 
     const q = (raw || "").trim().toLowerCase();
     this.currentQuery = q;
+
     const hasColumnFilters = this.columnFilters.size > 0;
 
     if (!q && !hasColumnFilters) {
       this.currentFilterPredicate = null;
       this.currentFilterOpts = null;
       this.tree.clearFilter();
+
       document.getElementById("tree-match-count")?.remove();
+
       this._setLoading(false);
       this._updateFilterModeButton();
       this._updateSelectAllButtonState();
+
       return;
     }
 
     this._showMatchCountStatus("Searching…");
     this._setLoading(true, "Searching…");
+
     await new Promise(requestAnimationFrame);
 
     const params = new URLSearchParams();
-    if (q) params.set("q", q);
+
+    if (q) {
+      params.set("q", q);
+    }
+
     for (const [col, val] of this.columnFilters.entries()) {
-      if (val !== "") params.set(col, val);
+      if (val !== "") {
+        params.set(col, val);
+      }
     }
 
     const searchCtrl = this._beginFetchGroup();
-    let folders = [], assets = [];
+
     try {
-      [folders, assets] = await Promise.all([
-        this._fetchJson(`/volumes/${this.volumeIdValue}/file_tree_folders_search.json?${params.toString()}`, searchCtrl).catch(() => []),
-        this._fetchJson(`/volumes/${this.volumeIdValue}/file_tree_assets_search.json?${params.toString()}`, searchCtrl).catch(() => []),
+      const [folderResponse, assetResponse] = await Promise.all([
+        this._fetchJson(
+          `/volumes/${this.volumeIdValue}/file_tree_folders_search.json?${params.toString()}`,
+          searchCtrl
+        ).catch(() => []),
+
+        this._fetchJson(
+          `/volumes/${this.volumeIdValue}/file_tree_assets_search.json?${params.toString()}`,
+          searchCtrl
+        ).catch(() => ({
+          results: [],
+          total_count: 0
+        }))
       ]);
 
-      if (mySeq !== this._filterSeq) return;
+      if (mySeq !== this._filterSeq) {
+        return;
+      }
+
+      let folders = [];
+
+      if (Array.isArray(folderResponse)) {
+        folders = folderResponse;
+      } else if (Array.isArray(folderResponse?.results)) {
+        folders = folderResponse.results;
+      }
+
+      let assets = [];
+
+      if (Array.isArray(assetResponse)) {
+        assets = assetResponse;
+      } else if (Array.isArray(assetResponse?.results)) {
+        assets = assetResponse.results;
+      }
+
+      this._buildFolderMatchCounts(assets);
+      const folderMatchCount = folders.length;
+
+      let backendAssetCount = assets.length;
+
+      if (
+        !Array.isArray(assetResponse) &&
+        assetResponse?.total_count != null
+      ) {
+        backendAssetCount = Number(assetResponse.total_count);
+      }
+
+      if (!Number.isFinite(backendAssetCount)) {
+        backendAssetCount = assets.length;
+      }
+
+      const hasFolderCapableFilters =
+        q.length > 0 ||
+        (this.columnFilters.has("assigned_to") &&
+          String(this.columnFilters.get("assigned_to") ?? "") !== "");
+
+      const backendMatchCount =
+        hasFolderCapableFilters
+          ? folderMatchCount + backendAssetCount
+          : backendAssetCount;
 
       if (!q && this.columnFilters.size > 0) {
-        await this._materializeColumnFilterResults(folders, assets, mySeq);
+        await this._materializeColumnFilterResults(
+          folders,
+          assets,
+          mySeq
+        );
       } else {
-        await this._materializeSearchResults(folders, assets, mySeq);
+        await this._materializeSearchResults(
+          folders,
+          assets,
+          mySeq
+        );
+      }
+
+      if (mySeq !== this._filterSeq) {
+        return;
       }
 
       this._applyPredicate(q);
+      this._updateMatchCount(backendMatchCount);
     } finally {
       this.inflightControllers.delete(searchCtrl);
       this._setLoading(false);
@@ -629,31 +731,32 @@ export default class extends Controller {
 
       for (const [colId, val] of this.columnFilters.entries()) {
         const normalizedValue = this._filterValueFor(colId, node.data);
-        const normalizedStr = normalizedValue == null ? "" : String(normalizedValue).toLowerCase();
+        const normalizedStr =
+          normalizedValue == null
+            ? ""
+            : String(normalizedValue).toLowerCase();
+
         const filterStr = String(val ?? "").toLowerCase();
 
         if (normalizedStr !== filterStr) return false;
       }
+
       return true;
     };
-    const opts = { leavesOnly: false, matchBranch: false, mode: this.filterMode };
+
+    const opts = {
+      leavesOnly: false,
+      matchBranch: false,
+      mode: this.filterMode
+    };
+
     this.currentFilterPredicate = predicate;
     this.currentFilterOpts = opts;
+
     this.tree.filterNodes(predicate, opts);
-    this._updateFilterModeButton();
-    this._updateSelectAllButtonState();
-
-    const count = this._countFilteredNodes();
-    this._updateMatchCount(count);
 
     this._updateFilterModeButton();
     this._updateSelectAllButtonState();
-
-    let debugCount = 0;
-    this.tree.visitRows((node) => {
-      if (node.statusNodeType) return;
-      debugCount += 1;
-    });
   }
 
   // Load and select all descendants for a folder node without blocking UI.
@@ -1521,21 +1624,6 @@ export default class extends Controller {
     }
   }
 
-  // Counts the number of matches
-  _countFilteredNodes() {
-    const predicate = this.currentFilterPredicate;
-    if (!predicate) return 0;
-
-    let count = 0;
-
-    this.tree.visit((node) => {
-      if (node.statusNodeType) return;
-      if (predicate(node)) count += 1;
-    });
-
-    return count;
-  }
-
   // Displays count for query search matches
   _updateMatchCount(count) {
     const input = document.getElementById("tree-filter");
@@ -1734,5 +1822,34 @@ export default class extends Controller {
     } catch (error) {
       console.error(`Failed to refresh assets for folder ${parentFolderId}:`, error);
     }
+  }
+
+  // Builds the number of selected assets that match each folder
+  _buildFolderMatchCounts(assets) {
+    const counts = new Map();
+
+    for (const asset of assets) {
+      const parentId =
+        asset.parent_folder_id ??
+        asset.folder_id;
+
+      const folderIds = new Set(
+        [
+          ...(Array.isArray(asset.path) ? asset.path : []),
+          parentId
+        ]
+          .filter((id) => id != null)
+          .map(String)
+      );
+
+      for (const folderId of folderIds) {
+        counts.set(
+          folderId,
+          (counts.get(folderId) || 0) + 1
+        );
+      }
+    }
+
+    this.folderMatchCounts = counts;
   }
 }

--- a/app/services/sync_service/assets.rb
+++ b/app/services/sync_service/assets.rb
@@ -36,6 +36,7 @@ module SyncService
         end
       end
 
+      backfill_descendant_asset_counts
       stdout_and_log("Imported #{imported} IsilonAsset records.")
     end
 
@@ -223,6 +224,23 @@ module SyncService
 
     def get_name(path)
       path.split("/").last
+    end
+
+    def backfill_descendant_asset_counts
+      folders = IsilonFolder.where(volume_id: @parent_volume.id)
+                            .select(:id, :parent_folder_id, :full_path)
+                            .order(Arel.sql("LENGTH(full_path) DESC"))
+
+      totals = IsilonAsset.where(volume_id: @parent_volume.id)
+                          .group(:parent_folder_id)
+                          .count
+                          .transform_keys { |key| key&.to_i }
+
+      folders.each do |folder|
+        total = totals.fetch(folder.id, 0)
+        totals[folder.parent_folder_id] = totals.fetch(folder.parent_folder_id, 0) + total if folder.parent_folder_id
+        folder.update_column(:descendant_assets_count, total)
+      end
     end
 
     def stdout_and_log(message, level: :info)

--- a/spec/requests/volumes/file_tree_spec.rb
+++ b/spec/requests/volumes/file_tree_spec.rb
@@ -160,6 +160,18 @@ RSpec.describe "Volumes file tree endpoints", type: :request do
       expect(response).to have_http_status(:ok)
       expect(parsed).to eq([])
     end
+
+    it "filters folders by assigned_to" do
+      folder_b.update!(assigned_to: assignee)
+
+      get "/volumes/#{volume.id}/file_tree_folders_search.json", params: { assigned_to: assignee.id }
+      expect(response).to have_http_status(:ok)
+
+      body = parsed
+      expect(body).to be_a(Array)
+      expect(body.map { |h| h["id"] }).to include(folder_b.id)
+      expect(body.map { |h| h["id"] }).not_to include(root.id)
+    end
   end
 
   describe "GET /volumes/:id/file_tree_assets_search" do
@@ -168,9 +180,13 @@ RSpec.describe "Volumes file tree endpoints", type: :request do
       expect(response).to have_http_status(:ok)
 
       body = parsed
-      expect(body).to be_a(Array)
+      expect(body).to include(
+        "results" => be_a(Array),
+        "total_count" => 1,
+        "returned_count" => 1
+      )
 
-      match = body.find { |h| h["id"] == asset.id }
+      match = body.fetch("results").find { |h| h["id"] == asset.id }
 
       expect(match).to be_present
       expect(match["folder"]).to eq(false)
@@ -183,7 +199,11 @@ RSpec.describe "Volumes file tree endpoints", type: :request do
     it "returns empty array when no assets match" do
       get "/volumes/#{volume.id}/file_tree_assets_search.json", params: { q: "zzz-not-found" }
       expect(response).to have_http_status(:ok)
-      expect(parsed).to eq([])
+      expect(parsed).to eq({
+        "results" => [],
+        "total_count" => 0,
+        "returned_count" => 0
+      })
     end
 
     it "filters assets by duplicate status" do
@@ -197,7 +217,10 @@ RSpec.describe "Volumes file tree endpoints", type: :request do
       expect(response).to have_http_status(:ok)
 
       body = parsed
-      ids = body.map { |h| h["id"] }
+      expect(body["total_count"]).to eq(1)
+      expect(body["returned_count"]).to eq(1)
+
+      ids = body.fetch("results").map { |h| h["id"] }
       expect(ids).to include(duplicate_asset.id)
       expect(ids).not_to include(asset.id)
     end

--- a/spec/system/file_tree_column_filter_spec.rb
+++ b/spec/system/file_tree_column_filter_spec.rb
@@ -62,6 +62,16 @@ RSpec.describe "File tree column filters", type: :system, js: true do
     )
   end
 
+  let!(:assigned_folder) do
+    create(
+      :isilon_folder,
+      volume: volume,
+      parent_folder: root_folder,
+      assigned_to: assignee_a,
+      full_path: "#{root_folder.full_path}/assigned-folder"
+    )
+  end
+
   before do
     driven_by :cuprite
     sign_in user
@@ -178,6 +188,24 @@ RSpec.describe "File tree column filters", type: :system, js: true do
     expect(page).to have_no_selector(".wb-row .wb-title", text: unassigned_asset.isilon_name, wait: 15)
   end
 
+  it "counts folder matches when filtering by assigned_to" do
+    find(
+      :xpath,
+      "//span[contains(@class,'wb-col-title')][normalize-space()='Assigned To']/parent::span[contains(@class,'wb-col')]/i[@data-command='filter']",
+      wait: 10
+    ).click
+
+    within(".wb-popup") do
+      find("option", text: assignee_a.name).select_option
+    end
+    page.execute_script("document.querySelector('.wb-popup select')?.dispatchEvent(new Event('change', { bubbles: true }))")
+
+    expect(page).to have_no_selector(".wb-loading", text: /Loading|Searching/i, wait: 10)
+    expect(page).to have_css("#tree-match-count", text: "2 matches", wait: 10)
+    expect(page).to have_selector(".wb-row .wb-title", text: assigned_asset.isilon_name, wait: 15)
+    expect(page).to have_selector(".wb-row .wb-title", text: "assigned-folder", wait: 15)
+  end
+
   it "filters assets by file type" do
     find(".wb-row .wb-expander", match: :first).click
     expect(page).to have_content(match_asset.isilon_name)
@@ -195,6 +223,7 @@ RSpec.describe "File tree column filters", type: :system, js: true do
     page.execute_script("document.querySelector('.wb-popup select')?.dispatchEvent(new Event('change', { bubbles: true }))")
 
     expect(page).to have_no_selector(".wb-loading", text: /Loading|Searching/i, wait: 10)
+    expect(page).to have_css("#tree-match-count", text: "1 matches", wait: 10)
     expect(page).to have_selector(".wb-row .wb-title", text: match_asset.isilon_name, wait: 15)
     expect(page).to have_no_selector(".wb-row .wb-title", text: other_asset.isilon_name, wait: 15)
   end

--- a/spec/system/file_tree_filter_spec.rb
+++ b/spec/system/file_tree_filter_spec.rb
@@ -110,13 +110,13 @@ RSpec.describe "file tree filtering", type: :system, js: true do
     expect(page).to have_no_content("scan_beta_001.tif", wait: 6)
   end
 
-  it "shows a match count for folder-only search matches" do
+  it "shows a match count for all folder-only search matches" do
     visit_volume_tree
 
     fill_in "tree-filter", with: "librarybeta"
 
     expect(page).to have_css("#tree-match-count", wait: 6)
-    expect(page).to have_css("#tree-match-count", text: "1 matches", wait: 6)
+    expect(page).to have_css("#tree-match-count", text: "4 matches", wait: 6)
   end
 
   it "does not apply stale search results after clearing the search" do

--- a/spec/system/file_tree_filter_spec.rb
+++ b/spec/system/file_tree_filter_spec.rb
@@ -110,13 +110,13 @@ RSpec.describe "file tree filtering", type: :system, js: true do
     expect(page).to have_no_content("scan_beta_001.tif", wait: 6)
   end
 
-  it "shows a match count after filtering" do
-    visit volume_path(volume)
+  it "shows a match count for folder-only search matches" do
+    visit_volume_tree
 
-    fill_in "tree-filter", with: "journals"
+    fill_in "tree-filter", with: "librarybeta"
 
     expect(page).to have_css("#tree-match-count", wait: 6)
-    expect(page).to have_text("matches")
+    expect(page).to have_css("#tree-match-count", text: "1 matches", wait: 6)
   end
 
   it "does not apply stale search results after clearing the search" do


### PR DESCRIPTION
This resolves a bug where not all matches were being included in the count.  This updates the count to come from the backend and also adds badge counts for matches in each folder.

**This PR is based on https://github.com/tulibraries/isilon-tracker/pull/426, so that should be merged first.**