### PR TITLE
Do not run db:setup in entrypoint

### DIFF
--- a/.docker/app/entrypoint.sh
+++ b/.docker/app/entrypoint.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
-rails db:migrate 2>/dev/null || rails db:setup
+rails db:migrate
+
 rm -f /app/.internal_test_app/tmp/pids/server.pid
 
 exec "$@"


### PR DESCRIPTION
I think the db:setup command is what is rewriting the database.  The current deployment is trying to do the same thing.