### PR TITLE
IMT-111 New settings for inactive users

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,22 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has()
   allow_browser versions: :modern
-  before_action :authenticate_user!
+  before_action :authenticate_user!, :ensure_active_user!
 
   include NavigationData
   include SessionTimeoutData
+
+  private
+
+  def ensure_active_user!
+    return unless user_signed_in?
+    return if current_user.active_status?
+
+    sign_out current_user
+
+    redirect_to(
+      new_user_session_path,
+      alert: "Your account is inactive."
+    )
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   def index
-    users = User.all
+    users = User.active_status.order(:name)
     render json: users.each_with_object({}) { |user, h| h[user.id] = user.name.presence || user.email }
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,6 +34,14 @@ class User < ApplicationRecord
     end
   end
 
+  def active_for_authentication?
+    super && active_status?
+  end
+
+  def inactive_message
+    :inactive
+  end
+
   protected
 
   def assign_names_from_name_field

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,5 +4,11 @@ FactoryBot.define do
   factory :user do
     sequence(:email) { |n| "#{(0...3).map { (65 + rand(26)).chr }.join}000#{n}@temple.edu" }
     password { "secret_password" }
+
+    status { :active }
+
+    trait :inactive do
+      status { :inactive }
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -115,4 +115,22 @@ RSpec.describe User, type: :model do
       expect(user.password).to eq("custompass")
     end
   end
+
+  describe "#active_for_authentication?" do
+    it "allows an active user to authenticate" do
+      user = build(:user, status: :active)
+
+      expect(
+        user.active_for_authentication?
+      ).to be(true)
+    end
+
+    it "prevents an inactive user from authenticating" do
+      user = build(:user, status: :inactive)
+
+      expect(
+        user.active_for_authentication?
+      ).to be(false)
+    end
+  end
 end

--- a/spec/requests/inactive_user_access_spec.rb
+++ b/spec/requests/inactive_user_access_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe "Inactive user access", type: :request do
+  let(:user) do
+    create(
+      :user,
+      status: :active
+    )
+  end
+
+  it "allows an active user to access the application" do
+    sign_in user
+
+    get root_path
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "signs out a user after their status becomes inactive" do
+    sign_in user
+
+    user.inactive_status!
+
+    get root_path
+
+    expect(response).to redirect_to(
+      new_user_session_path
+    )
+  end
+end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe "Users", type: :request do
+  describe "GET /users.json" do
+    let(:current_user) do
+      create(
+        :user,
+        status: :active,
+        name: "Current User"
+      )
+    end
+
+    let!(:active_user) do
+      create(
+        :user,
+        status: :active,
+        name: "Active Person"
+      )
+    end
+
+    let!(:inactive_user) do
+      create(
+        :user,
+        status: :inactive,
+        name: "Inactive Person"
+      )
+    end
+
+    before do
+      sign_in current_user
+    end
+
+    it "returns active users and excludes inactive users" do
+      get "/users.json"
+
+      expect(response).to have_http_status(:ok)
+
+      users = JSON.parse(response.body)
+
+      expect(users).to include(
+        current_user.id.to_s => "Current User",
+        active_user.id.to_s => "Active Person"
+      )
+
+      expect(users).not_to include(
+        inactive_user.id.to_s
+      )
+    end
+
+    it "uses the email when an active user has no name" do
+      user_without_name = create(
+        :user,
+        status: :active,
+        name: nil,
+        email: "noname@example.com"
+      )
+
+      get "/users.json"
+
+      users = JSON.parse(response.body)
+
+      expect(users).to include(
+        user_without_name.id.to_s =>
+          "noname@example.com"
+      )
+    end
+  end
+end


### PR DESCRIPTION
* Do not allow inactive users to log in to the site
* Do not display inactive user names in the assigned_to dropdown
* Keeps all assets previously assigned to the inactive user as is